### PR TITLE
ATR: Fix applying strength up/down

### DIFF
--- a/float/float/float.c
+++ b/float/float/float.c
@@ -1356,7 +1356,12 @@ static void apply_torquetilt(data *d) {
 		d->accel_gap = 0;
 	}
 
-	float atr_strength = (d->accel_gap > 0) ? d->float_conf.atr_strength_up : d->float_conf.atr_strength_down;
+	// d->accel_gap | > 0  | <= 0
+	// -------------+------+-------
+	//      forward | up   | down
+	//     !forward | down | up
+	float atr_strength = forward == (d->accel_gap > 0) ? d->float_conf.atr_strength_up : d->float_conf.atr_strength_down;
+
 	// from 3000 to 6000 erpm gradually crank up the torque response
 	if ((d->abs_erpm > 3000) && (!d->braking)) {
 		float speedboost = (d->abs_erpm - 3000) / 3000;


### PR DESCRIPTION
When going backwards (battery forward), the sign for the accel_gap is inverted. Without the fix, the wrong ATR strength was being applied, so e.g. setting only ATR uphill, the nose would instead angle down on a downhill if going battery forward.